### PR TITLE
Assorted minor fixes and performance improvements

### DIFF
--- a/commit.go
+++ b/commit.go
@@ -93,14 +93,14 @@ l:
 			reftype := line[:spacepos]
 			switch string(reftype) {
 			case "tree":
-				oid, err := NewOidFromString(string(line[spacepos+1:]))
+				oid, err := NewOidFromByteString(line[spacepos+1:])
 				if err != nil {
 					return nil, err
 				}
 				commit.treeId = oid
 			case "parent":
 				// A commit can have one or more parents
-				oid, err := NewOidFromString(string(line[spacepos+1:]))
+				oid, err := NewOidFromByteString(line[spacepos+1:])
 				if err != nil {
 					return nil, err
 				}

--- a/commit.go
+++ b/commit.go
@@ -147,10 +147,10 @@ func (repos *Repository) LookupCommit(oid *Oid) (*Commit, error) {
 		return nil, err
 	}
 	tree, err := parseTreeData(data)
-	tree.Oid = ci.TreeId()
 	if err != nil {
 		return nil, err
 	}
+	tree.Oid = ci.TreeId()
 	tree.repository = repos
 	ci.Tree = tree
 	return ci, nil

--- a/repository.go
+++ b/repository.go
@@ -74,9 +74,7 @@ type Object struct {
 
 // idx-file
 type idxFile struct {
-	indexpath   string
-	packpath    string
-	packversion uint32
+	packpath string
 
 	fanoutTable [256]int64
 
@@ -88,7 +86,6 @@ type idxFile struct {
 
 func readIdxFile(path string) (*idxFile, error) {
 	ifile := &idxFile{}
-	ifile.indexpath = path
 	ifile.packpath = path[0:len(path)-3] + "pack"
 
 	idxf, err := os.Open(path)
@@ -135,7 +132,6 @@ func readIdxFile(path string) (*idxFile, error) {
 	if !bytes.HasPrefix(packVersion, []byte{'P', 'A', 'C', 'K'}) {
 		return nil, errors.New("Pack file does not start with 'PACK'")
 	}
-	ifile.packversion = binary.BigEndian.Uint32(packVersion[4:8])
 	return ifile, nil
 }
 

--- a/repository.go
+++ b/repository.go
@@ -128,8 +128,8 @@ func readIdxFile(path string) (*idxFile, error) {
 	defer fi.Close()
 
 	packVersion := make([]byte, 8)
-	_, err = fi.Read(packVersion)
-	if err != nil && err != io.EOF {
+	_, err = io.ReadFull(fi, packVersion)
+	if err != nil {
 		return nil, err
 	}
 	if !bytes.HasPrefix(packVersion, []byte{'P', 'A', 'C', 'K'}) {


### PR DESCRIPTION
Performance impact of the entire PR:

```
name                            old time/op    new time/op    delta
LookupReference/HEAD-8            13.5µs ±15%    12.6µs ± 2%   -6.47%         (p=0.008 n=10+9)
LookupReference/master-8          6.47µs ± 3%    6.47µs ± 3%     ~             (p=0.931 n=9+9)
LookupReference/doesnotexist-8    17.7µs ± 1%    18.1µs ± 4%   +2.32%         (p=0.009 n=8+10)

name                            old alloc/op   new alloc/op   delta
LookupReference/HEAD-8            2.29kB ± 0%    2.16kB ± 0%   -5.59%        (p=0.000 n=10+10)
LookupReference/master-8          1.22kB ± 0%    1.10kB ± 0%  -10.46%        (p=0.000 n=10+10)
LookupReference/doesnotexist-8    9.02kB ± 0%    9.02kB ± 0%     ~     (all samples are equal)

name                            old allocs/op  new allocs/op  delta
LookupReference/HEAD-8              19.0 ± 0%      16.0 ± 0%  -15.79%        (p=0.000 n=10+10)
LookupReference/master-8            11.0 ± 0%       8.0 ± 0%  -27.27%        (p=0.000 n=10+10)
LookupReference/doesnotexist-8      17.0 ± 0%      17.0 ± 0%     ~     (all samples are equal)
```
